### PR TITLE
Update instructions to create device identity

### DIFF
--- a/setup_iothub.md
+++ b/setup_iothub.md
@@ -83,7 +83,7 @@ To build applications to manage the IoT hub and interact with devices from the C
 [for Node.js]: https://docs.microsoft.com/azure/iot-hub/iot-hub-node-node-getstarted#create-a-device-identity
 [for java]: https://docs.microsoft.com/azure/iot-hub/iot-hub-java-java-getstarted#create-a-device-identity
 [for Python]: https://github.com/Azure/azure-iot-sdk-python/tree/master/service/samples
-[using Azure CLI v2.0]: https://docs.microsoft.com/cli/azure/iot/device#create
+[using Azure CLI v2.0]: https://docs.microsoft.com/cli/azure/ext/azure-cli-iot-ext/iot/hub/device-identity?view=azure-cli-latest#ext-azure-cli-iot-ext-az-iot-hub-device-identity-create
 [Azure IoT service client SDK for C#]: https://github.com/Azure/azure-iot-sdk-csharp/tree/master/service
 [Azure IoT service client SDK for Node.js]: https://github.com/azure/azure-iot-sdk-node/tree/master/service
 [Azure IoT service client SDK for Java]: https://github.com/azure/azure-iot-sdk-java/tree/master/service


### PR DESCRIPTION
There is a new az cli extention to create device identities. The old link went to a 404. Link is now updated to the new location.