### PR TITLE
add libssl-dev and uuid-dev to installs

### DIFF
--- a/get_started/debian-beaglebone-black-c.md
+++ b/get_started/debian-beaglebone-black-c.md
@@ -65,7 +65,7 @@ You should have the following items ready before beginning the process:
 
         sudo apt-get update
 
-        sudo apt-get install -y curl libcurl4-openssl-dev build-essential cmake git
+        sudo apt-get install -y curl libssl-dev libcurl4-openssl-dev build-essential uuid-dev cmake git
 
     ***Note:*** *This setup process requires cmake version 2.8.12 or higher.* 
     


### PR DESCRIPTION
Fixes #257 

I hit the same errors mentioned in the linked bug.
This fixes the documented steps so they will work right off the bat for the next person.