### PR TITLE
added missing instruction, resolves #728

### DIFF
--- a/get_started/rasbian-linux-optiga-tpm-slb-9670-c.md
+++ b/get_started/rasbian-linux-optiga-tpm-slb-9670-c.md
@@ -95,6 +95,7 @@ On the Raspberry Pi, build a C SDK tool that you can use to retrieve the device'
     
 2.  Run the following commands to build an C SDK tool that retrieves your device provisioning information. 
 
+        mkdir azure-iot-sdk-c/cmake
         cd azure-iot-sdk-c/cmake
         cmake -Duse_prov_client:BOOL=ON ..
         cd provisioning_client/tools/tpm_device_provision

--- a/get_started/raspbian-linux-optiga-tpm-slb-9670-iridium-board-c.md
+++ b/get_started/raspbian-linux-optiga-tpm-slb-9670-iridium-board-c.md
@@ -82,6 +82,7 @@ On the Raspberry Pi, build a C SDK tool that you can use to retrieve the device'
     
 2. Run the following commands to build an C SDK tool that retrieves your device provisioning information. 
 
+       mkdir azure-iot-sdk-c/cmake
        cd azure-iot-sdk-c/cmake
        cmake -Duse_prov_client:BOOL=ON ..
        cd provisioning_client/tools/tpm_device_provision


### PR DESCRIPTION
In [azure-iot-device-ecosystem/get_started/raspbian-linux-optiga-tpm-slb-9670-iridium-board-c.md](https://github.com/Azure/azure-iot-device-ecosystem/blob/master/get_started/raspbian-linux-optiga-tpm-slb-9670-iridium-board-c.md), there is a step missing to create the cmake directory.

Point 2:
missing:
`mkdir azure-iot-sdk-c/cmake`

before:
```
cd azure-iot-sdk-c/cmake
cmake -Duse_prov_client:BOOL=ON ..
cd provisioning_client/tools/tpm_device_provision
make
sudo ./tpm_device_provision
```